### PR TITLE
Check for null focus widget

### DIFF
--- a/src/fullkeyboard.cpp
+++ b/src/fullkeyboard.cpp
@@ -209,8 +209,11 @@ void FullKeyboard::keyHandler()
             chr = presskey+32;
         QKeyEvent keyPress(QEvent::KeyPress, presskey, modifier, QString(chr));
         QWidget* w = QApplication::focusWidget();
-        QApplication::sendEvent(w, &keyPress);
-        if (m_shiftActivated)
-            processShift();
+        if (w)
+        {
+            QApplication::sendEvent(w, &keyPress);
+            if (m_shiftActivated)
+                processShift();
+        }
     }
 }


### PR DESCRIPTION
From Qt docs:
```
QWidget *QApplication::focusWidget()

Returns the application widget that has the keyboard input focus, or 0 if no widget in this application has the focus.
```