### PR TITLE
Option for setting an explicit key event receiver

### DIFF
--- a/sip/QOnScreenKeyboard.sip
+++ b/sip/QOnScreenKeyboard.sip
@@ -20,6 +20,9 @@ public:
         Custom
     };
     explicit QOnScreenKeyboard(QWidget* parent=0, QOnScreenKeyboard::KeyboardType kbdType=QOnScreenKeyboard::Full);
+
+    void setReceiver(QWidget* receiver);
+    QWidget* receiver();
 };
 
 %End

--- a/sip/QOnScreenKeyboard.sip
+++ b/sip/QOnScreenKeyboard.sip
@@ -22,7 +22,7 @@ public:
     explicit QOnScreenKeyboard(QWidget* parent=0, QOnScreenKeyboard::KeyboardType kbdType=QOnScreenKeyboard::Full);
 
     void setReceiver(QWidget* receiver);
-    QWidget* receiver();
+    QWidget* receiver() const;
 };
 
 %End

--- a/src/IKeyboard.h
+++ b/src/IKeyboard.h
@@ -2,11 +2,18 @@
 #define _KEYBOARD_IFACE_H_ 
 
 #include <QWidget>
+#include <QPointer>
 
 class IKeyboard : public QWidget
 {
     public:
         IKeyboard(QWidget *parent):
             QWidget(parent){}
+
+        void setReceiver(QWidget* receiver) { mReceiver = receiver; }
+        QWidget* receiver() { return mReceiver; }
+
+    protected:
+        QPointer<QWidget> mReceiver;
 };
 #endif //_KEYBOARD_IFACE_H_ 

--- a/src/IKeyboard.h
+++ b/src/IKeyboard.h
@@ -11,7 +11,7 @@ class IKeyboard : public QWidget
             QWidget(parent){}
 
         void setReceiver(QWidget* receiver) { mReceiver = receiver; }
-        QWidget* receiver() { return mReceiver; }
+        QWidget* receiver() const { return mReceiver; }
 
     protected:
         QPointer<QWidget> mReceiver;

--- a/src/fullkeyboard.cpp
+++ b/src/fullkeyboard.cpp
@@ -208,7 +208,7 @@ void FullKeyboard::keyHandler()
         if ((presskey >= 65) && (presskey <= 90) && (!m_shiftActivated) && (!m_capsActivated))
             chr = presskey+32;
         QKeyEvent keyPress(QEvent::KeyPress, presskey, modifier, QString(chr));
-        QWidget* w = QApplication::focusWidget();
+        QWidget* w = mReceiver.isNull() ? QApplication::focusWidget() : mReceiver.data();
         if (w)
         {
             QApplication::sendEvent(w, &keyPress);

--- a/src/fullkeyboard.ui
+++ b/src/fullkeyboard.ui
@@ -935,7 +935,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="2,4,2,2,0,0,2,0,2,2,4,2">
+       <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="2,4,2,2,2,2,2,2,2,2,4,2">
         <property name="spacing">
          <number>2</number>
         </property>

--- a/src/numpadkeyboard.cpp
+++ b/src/numpadkeyboard.cpp
@@ -36,7 +36,7 @@ void NumpadKeyboard::keyHandler()
     QChar chr(presskey);
     printf("%d\n",presskey);
     QKeyEvent keyPress(QEvent::KeyPress, presskey, Qt::NoModifier, QString(chr));
-    QWidget* w = QApplication::focusWidget();
+    QWidget* w = mReceiver.isNull() ? QApplication::focusWidget() : mReceiver.data();
     if (w)
         QApplication::sendEvent(w, &keyPress);
 }

--- a/src/qonscreenkeyboard.cpp
+++ b/src/qonscreenkeyboard.cpp
@@ -29,7 +29,7 @@ void QOnScreenKeyboard::setReceiver(QWidget* receiver)
     m_pKeyboard->setReceiver(receiver);
 }
 
-QWidget* QOnScreenKeyboard::receiver()
+QWidget* QOnScreenKeyboard::receiver() const
 {
     return m_pKeyboard->receiver();
 }

--- a/src/qonscreenkeyboard.cpp
+++ b/src/qonscreenkeyboard.cpp
@@ -24,3 +24,13 @@ QOnScreenKeyboard::QOnScreenKeyboard(QWidget *parent, KeyboardType kbdType):
 
 }
 
+void QOnScreenKeyboard::setReceiver(QWidget* receiver)
+{
+    m_pKeyboard->setReceiver(receiver);
+}
+
+QWidget* QOnScreenKeyboard::receiver()
+{
+    return m_pKeyboard->receiver();
+}
+

--- a/src/qonscreenkeyboard.h
+++ b/src/qonscreenkeyboard.h
@@ -26,7 +26,7 @@ public:
     QOnScreenKeyboard(QWidget* parent=0, KeyboardType kbdType=Full);
 
     void setReceiver(QWidget* receiver);
-    QWidget* receiver();
+    QWidget* receiver() const;
 
 private:
     KeyboardType m_kbdType;

--- a/src/qonscreenkeyboard.h
+++ b/src/qonscreenkeyboard.h
@@ -25,6 +25,9 @@ public:
     };
     QOnScreenKeyboard(QWidget* parent=0, KeyboardType kbdType=Full);
 
+    void setReceiver(QWidget* receiver);
+    QWidget* receiver();
+
 private:
     KeyboardType m_kbdType;
     IKeyboard *m_pKeyboard;


### PR DESCRIPTION
You can now set which widget receives key events. If none is specified (default option), the focus widget will be used instead.

I also threw in a little fix for layout stretch.